### PR TITLE
feat: add dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "React Bootstrap Extensions",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "18",
+      "nodeGypDependencies": true
+    }
+  },
+  "postCreateCommand": "corepack enable && yarn install --immutable",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}
+

--- a/README.md
+++ b/README.md
@@ -41,3 +41,10 @@ You don't have to ever use `eject`. The curated feature set is suitable for smal
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+## Dev Container
+
+You can develop inside a container with VS Code's Dev Containers extension.
+After opening the project, select **Reopen in Container**. Dependencies are
+installed automatically.
+


### PR DESCRIPTION
## Purpose
Add a VS Code development container to streamline onboarding.

## Changes
- add `.devcontainer/devcontainer.json`
- document usage in `README.md`

## Verification
- [x] `yarn lint`
- [x] `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6863de966308832699122609489e67a8