### PR TITLE
chore: update docs and deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) **18+**
+- Install dependencies with `yarn install` before running scripts.
+
 ## Available Scripts
 
 In the project directory, you can run:
@@ -16,7 +21,7 @@ You may also see any lint errors in the console.
 
 ### `yarn test`
 
-Lints.
+Runs lint checks.
 
 ### `yarn build`
 

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
     "dist"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.9",
+    "@popperjs/core": "^2.11.8",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.4.3",
@@ -68,7 +69,7 @@
     "@storybook/react": "^7.6.6",
     "@storybook/react-webpack5": "^7.6.10",
     "@storybook/testing-library": "^0.2.2",
-    "@types/jest": "^26.0.24",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20.10.6",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3770,13 +3770,13 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^26.0.24":
-  version "26.0.24"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
-  integrity sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==
+"@types/jest@^30.0.0":
+  version "30.0.0"
+  resolved "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz"
+  integrity sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==
   dependencies:
-    jest-diff "^26.0.0"
-    pretty-format "^26.0.0"
+    expect "^30.0.0"
+    pretty-format "^30.0.0"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.15"


### PR DESCRIPTION
## Purpose
- clarify prerequisites in README
- bump @types/jest and add popper peer
- require Node 18

## Validation
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6864d5b8ad288326ba19aded0ba7cff9

## Summary by Sourcery

Update documentation and bump project dependencies

Build:
- Require Node.js >= 18 in package.json engines
- Add @popperjs/core as a dependency
- Upgrade @types/jest to v30

Documentation:
- Add Node.js 18+ prerequisite and install step to README
- Clarify description of the yarn test script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a new "Prerequisites" section specifying Node.js 18+ and clearer instructions for running lint checks.

* **Chores**
  * Increased the minimum required Node.js version to 18.
  * Added "@popperjs/core" as a new runtime dependency.
  * Upgraded "@types/jest" development dependency to version 30.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->