### PR TITLE
chore: require node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: yarn
       - name: Update Brew (macOS)
         if: matrix.os == 'macOS-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        node: ["16", "18", "19", "20"]
+        node: ["18"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup node

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## 🛠️ Tooling
 - **Package manager:** Yarn (`yarn install` before every run).
-- **Node version:** ≥ 16 LTS (check `.nvmrc` if present).
+- **Node version:** ≥ 18 LTS (check `.nvmrc` if present).
 - **Build:** `yarn build` → outputs CJS, ESM & UMD bundles to `dist/`.
 - **Storybook dev:** `yarn start` (port 6006).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) **18+**
+- [Node.js](https://nodejs.org/) **18+** (LTS)
 - Install dependencies with `yarn install` before running scripts.
 
 ## Available Scripts


### PR DESCRIPTION
## Summary
- document Node 18 LTS as the minimum
- adjust CI workflows to use Node 18

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6864fa132a2083268712f9e6a7ccb8c7

## Summary by Sourcery

Require Node.js 18 LTS as the minimum supported version across the project by bumping engine requirements, adjusting CI workflows, and updating documentation.

Enhancements:
- Bump Node.js requirement to 18 LTS.

Build:
- Update CI workflows to use Node.js 18 exclusively.

Documentation:
- Document Node.js 18 LTS as the minimum supported version in README and AGENTS.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to use Node.js 18.x exclusively.
  * Simplified test matrix to run tests only on Node.js 18 across all supported operating systems.

* **Documentation**
  * Updated documentation to specify Node.js 18 LTS as the minimum required version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->