### PR TITLE
chore: enable Corepack in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           node-version: 18.x
           cache: yarn
+      - run: corepack enable && yarn --version
       - name: Update Brew (macOS)
         if: matrix.os == 'macOS-latest'
         run: brew update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
+      - run: corepack enable && yarn --version
       - name: Install packages
         run: yarn install
       - name: Run tests


### PR DESCRIPTION
## Purpose
Enable Corepack so GitHub Actions use the repo's yarnPath.

## Changes
- add corepack enable step in CI and test jobs

## Checklist
- [x] `yarn lint && yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6867bef3fd248326945ac04a7aa0cdd7