### PR TITLE
Fix React-Bootstrap styled-components compatibility and recursion bug

### DIFF
--- a/src/components/Block.tsx
+++ b/src/components/Block.tsx
@@ -13,6 +13,7 @@ export interface BlockProps extends React.HTMLAttributes<HTMLElement>, BsPrefixP
    * The general visual variant a the Block.
    */
   variant?: 'dark' | string;
+  as?: React.ElementType;
 };
 
 const propTypes = {

--- a/src/components/BlockBackground.tsx
+++ b/src/components/BlockBackground.tsx
@@ -3,7 +3,9 @@ import classNames from 'classnames';
 import { BsPrefixProps } from 'react-bootstrap/esm/helpers';
 import { useBootstrapPrefix } from 'react-bootstrap/esm/ThemeProvider';
 
-export interface BlockBackgroundProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {};
+export interface BlockBackgroundProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {
+  as?: React.ElementType;
+};
 
 const propTypes = {};
 

--- a/src/components/BlockForeground.tsx
+++ b/src/components/BlockForeground.tsx
@@ -3,7 +3,9 @@ import classNames from 'classnames';
 import { BsPrefixProps } from 'react-bootstrap/esm/helpers';
 import { useBootstrapPrefix } from 'react-bootstrap/esm/ThemeProvider';
 
-export interface BlockForegroundProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {};
+export interface BlockForegroundProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {
+  as?: React.ElementType;
+};
 
 const propTypes = {};
 

--- a/src/components/BlockTitle.tsx
+++ b/src/components/BlockTitle.tsx
@@ -3,7 +3,9 @@ import classNames from 'classnames';
 import { BsPrefixProps } from 'react-bootstrap/esm/helpers';
 import { useBootstrapPrefix } from 'react-bootstrap/esm/ThemeProvider';
 
-export interface BlockTitleProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {};
+export interface BlockTitleProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {
+  as?: React.ElementType;
+};
 
 const propTypes = {};
 

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ContainerProps as BsContainerProps } from "react-bootstrap";
+import { Container as BsContainer, ContainerProps as BsContainerProps } from "react-bootstrap";
 import classNames from 'classnames';
 import { BsPrefixProps } from "react-bootstrap/esm/helpers";
 import { useBootstrapPrefix } from 'react-bootstrap/esm/ThemeProvider';
@@ -16,6 +16,7 @@ export interface ContainerProps extends BsContainerProps, BsPrefixProps {
    * Content middle.
    */
   contentMiddle?: boolean;
+  as?: React.ElementType;
 }
 
 const propTypes = {
@@ -37,6 +38,7 @@ const Container: React.ForwardRefExoticComponent<ContainerProps & React.RefAttri
   (
     {
       bsPrefix,
+      as: Component = 'div',
       className,
       fillHeight,
       contentMiddle,
@@ -47,7 +49,8 @@ const Container: React.ForwardRefExoticComponent<ContainerProps & React.RefAttri
     bsPrefix = useBootstrapPrefix(bsPrefix, 'container');
 
     return (
-      <Container
+      <BsContainer
+        as={Component}
         ref={ref}
         {...props}
         className={classNames(

--- a/src/components/FeaturedList.tsx
+++ b/src/components/FeaturedList.tsx
@@ -5,7 +5,9 @@ import { useBootstrapPrefix } from 'react-bootstrap/esm/ThemeProvider';
 import FeaturedListIcon from './FeaturedListIcon';
 import FeaturedListItem from './FeaturedListItem';
 
-export interface FeaturedListProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {};
+export interface FeaturedListProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {
+  as?: React.ElementType;
+};
 
 const propTypes = {};
 

--- a/src/components/FeaturedListIcon.tsx
+++ b/src/components/FeaturedListIcon.tsx
@@ -3,7 +3,9 @@ import classNames from 'classnames';
 import { BsPrefixProps } from 'react-bootstrap/esm/helpers';
 import { useBootstrapPrefix } from 'react-bootstrap/esm/ThemeProvider';
 
-export interface FeaturedListIconProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {};
+export interface FeaturedListIconProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {
+  as?: React.ElementType;
+};
 
 const propTypes = {};
 

--- a/src/components/FeaturedListItem.tsx
+++ b/src/components/FeaturedListItem.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { BsPrefixProps } from 'react-bootstrap/esm/helpers';
 
-export interface FeaturedListItemProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {};
+export interface FeaturedListItemProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {
+  as?: React.ElementType;
+};
 
 const propTypes = {};
 

--- a/src/components/IconList.tsx
+++ b/src/components/IconList.tsx
@@ -3,7 +3,9 @@ import classNames from 'classnames';
 import { BsPrefixProps } from 'react-bootstrap/esm/helpers';
 import { useBootstrapPrefix } from 'react-bootstrap/esm/ThemeProvider';
 
-export interface IconListProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {};
+export interface IconListProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {
+  as?: React.ElementType;
+};
 
 const propTypes = {};
 

--- a/src/components/ProfileHeader.tsx
+++ b/src/components/ProfileHeader.tsx
@@ -3,7 +3,9 @@ import classNames from 'classnames';
 import { BsPrefixProps } from 'react-bootstrap/esm/helpers';
 import { useBootstrapPrefix } from 'react-bootstrap/esm/ThemeProvider';
 
-export interface ProfileHeaderProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {};
+export interface ProfileHeaderProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {
+  as?: React.ElementType;
+};
 
 const propTypes = {};
 

--- a/src/components/PullQuote.tsx
+++ b/src/components/PullQuote.tsx
@@ -10,10 +10,11 @@ export interface PullQuoteProps extends React.HTMLAttributes<HTMLElement>, BsPre
    * The general visual variant a the Pull Quote.
    */
   variant?: 'dark' | string;
+  as?: React.ElementType;
 };
 
 const propTypes = {
-  
+
   /**
    * The general visual variant a the Pull Quote.
    */

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -5,7 +5,9 @@ import { useBootstrapPrefix } from 'react-bootstrap/esm/ThemeProvider';
 import StatCardDesc from './StatCardDesc';
 import StatCardNumber from './StatCardNumber';
 
-export interface StatCardProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {};
+export interface StatCardProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {
+  as?: React.ElementType;
+};
 
 const propTypes = {};
 

--- a/src/components/StatCardDesc.tsx
+++ b/src/components/StatCardDesc.tsx
@@ -3,7 +3,9 @@ import classNames from 'classnames';
 import { BsPrefixProps } from 'react-bootstrap/esm/helpers';
 import { useBootstrapPrefix } from 'react-bootstrap/esm/ThemeProvider';
 
-export interface StatCardDescProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {};
+export interface StatCardDescProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {
+  as?: React.ElementType;
+};
 
 const propTypes = {};
 

--- a/src/components/StatCardNumber.tsx
+++ b/src/components/StatCardNumber.tsx
@@ -3,7 +3,9 @@ import classNames from 'classnames';
 import { BsPrefixProps } from 'react-bootstrap/esm/helpers';
 import { useBootstrapPrefix } from 'react-bootstrap/esm/ThemeProvider';
 
-export interface StatCardNumberProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {};
+export interface StatCardNumberProps extends React.HTMLAttributes<HTMLElement>, BsPrefixProps {
+  as?: React.ElementType;
+};
 
 const propTypes = {};
 


### PR DESCRIPTION
I have addressed the styled-components compatibility issue by explicitly adding the `as` prop to the TypeScript interfaces of all relevant components. While the destructuring was already present in many cases, its absence from the interfaces caused type errors.

Additionally, I identified and fixed a critical bug in `src/components/Container.tsx` where the component was recursively calling itself, which would cause a stack overflow in a React environment. I've updated it to use `Container as BsContainer` from `react-bootstrap`.

Components updated:
- Block
- BlockBackground
- BlockForeground
- BlockTitle
- Container
- FeaturedList
- FeaturedListIcon
- FeaturedListItem
- IconList
- ProfileHeader
- PullQuote
- StatCard
- StatCardDesc
- StatCardNumber

---
*PR created automatically by Jules for task [6737967383892156883](https://jules.google.com/task/6737967383892156883) started by @SmolSoftBoi*

## Summary by Sourcery

Improve react-bootstrap container usage and extend polymorphic support across layout components.

Bug Fixes:
- Fix Container component recursion by rendering react-bootstrap Container as an inner component instead of calling itself.

Enhancements:
- Expose an explicit polymorphic `as` prop on multiple layout and typography components to align TypeScript types with existing usage and styled-components patterns.