### PR TITLE
Potential fix for code scanning alert no. 2: Shell command built from environment values

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -25,19 +25,35 @@ const step = (name, fn) => async () => {
   console.log(cyan('Built: ') + green(name));
 };
 
-const shell = (cmd) =>
-  execa(cmd, { stdio: ['pipe', 'pipe', 'inherit'], shell: true });
+const run = (command, args = []) =>
+  execa(command, args, { stdio: ['pipe', 'pipe', 'inherit'] });
 
 const has = (t) => !targets.length || targets.includes(t);
 
-const buildTypes = step('generating .d.ts', () => shell(`yarn build-types`));
+const buildTypes = step('generating .d.ts', () => run('yarn', ['build-types']));
 
-const copyTypes = (dest) => shell(`cpy ${typesRoot}/*.d.ts ${dest}`);
+const copyTypes = async (dest) => {
+  const entries = fse.readdirSync(typesRoot);
+  const dtsFiles = entries.filter((name) => name.endsWith('.d.ts'));
+
+  await Promise.all(
+    dtsFiles.map((name) =>
+      fse.copy(path.join(typesRoot, name), path.join(dest, name)),
+    ),
+  );
+};
 
 const babel = (outDir, envName) =>
-  shell(
-    `yarn babel ${srcRoot} -x .es6,.js,.es,.jsx,.mjs,.ts,.tsx --out-dir ${outDir} --env-name "${envName}"`,
-  );
+  run('yarn', [
+    'babel',
+    srcRoot,
+    '-x',
+    '.es6,.js,.es,.jsx,.mjs,.ts,.tsx',
+    '--out-dir',
+    outDir,
+    '--env-name',
+    envName,
+  ]);
 
 /**
  * Run babel over the src directory and output


### PR DESCRIPTION
Potential fix for [https://github.com/SmolSoftBoi/react-bootstrap-extensions/security/code-scanning/2](https://github.com/SmolSoftBoi/react-bootstrap-extensions/security/code-scanning/2)

Use `execa` without `shell: true`, and pass command + arguments separately so paths are never shell-interpreted.

Best fix in `tools/build.js`:
- Replace the `shell(cmd)` wrapper with a helper that accepts `(command, args)` and calls `execa(command, args, { stdio: [...] })`.
- Update `buildTypes`, `copyTypes`, and `babel` to pass arguments as arrays instead of interpolated shell strings.
- For `copyTypes`, avoid shell glob expansion (`*.d.ts`) by enumerating `.d.ts` files with `fs-extra` + `path` and copying them directly via `fse.copy`.
- Keep existing behavior and logging; only command execution/copy mechanism changes.

No new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden the build tooling against shell injection by removing shell-based command execution and handling type file copying directly in Node.

Enhancements:
- Replace the generic shell helper with a safer execa-based runner that passes commands and arguments separately.
- Update type generation and Babel build steps to use argument arrays instead of interpolated shell strings.
- Reimplement the type copy step to enumerate and copy .d.ts files directly from Node instead of relying on shell glob expansion.